### PR TITLE
Target is string

### DIFF
--- a/src/bpe_task.erl
+++ b/src/bpe_task.erl
@@ -10,8 +10,8 @@ find_flow(Stage,List) -> case lists:member(Stage,List) of
                               _ -> find_flow(List) end.
 
 targets(Curr,Proc) ->
-    Targets = lists:flatten([ Target || #sequenceFlow{source=Source,target=Target} <- Proc#process.flows, 
-                Source==Curr]).
+    [ Target || #sequenceFlow{source=Source,target=Target} <- Proc#process.flows, 
+      Source==Curr].
 
 denied_flow(Curr,Proc) ->
     {reply,{denied_flow,Curr},Proc}.


### PR DESCRIPTION
If Target is a string like this:
   lists:flatten(["end"])    => "end"
But we need a ["end"] list.